### PR TITLE
Add recipe/ingredient publishers

### DIFF
--- a/ChopChop/Storage/StorageManager.swift
+++ b/ChopChop/Storage/StorageManager.swift
@@ -109,6 +109,10 @@ struct StorageManager {
 
     // MARK: - Database Access: Publishers
 
+    func recipePublisher(id: Int64) -> AnyPublisher<Recipe?, Error> {
+        appDatabase.recipePublisher(id: id)
+    }
+
     func recipesPublisher(query: String,
                           categoryIds: [Int64?],
                           ingredients: [String]) -> AnyPublisher<[RecipeInfo], Error> {
@@ -129,15 +133,19 @@ struct StorageManager {
             .eraseToAnyPublisher()
     }
 
+    func ingredientPublisher(id: Int64) -> AnyPublisher<Ingredient?, Error> {
+        appDatabase.ingredientPublisher(id: id)
+    }
+
     func ingredientsPublisher() -> AnyPublisher<[IngredientInfo], Error> {
         appDatabase.ingredientsPublisher()
-            .map { $0.map { IngredientInfo(id: $0.id, name: $0.name, quantity: String($0.totalQuantity)) } }
+            .map { $0.map { IngredientInfo(id: $0.id, name: $0.name, quantity: String($0.totalQuantityDescription)) } }
             .eraseToAnyPublisher()
     }
 
     func ingredientsPublisher(query: String, categoryIds: [Int64?]) -> AnyPublisher<[IngredientInfo], Error> {
         appDatabase.ingredientsPublisher(query: query, categoryIds: categoryIds)
-            .map { $0.map { IngredientInfo(id: $0.id, name: $0.name, quantity: String($0.totalQuantity)) } }
+            .map { $0.map { IngredientInfo(id: $0.id, name: $0.name, quantity: String($0.totalQuantityDescription)) } }
             .eraseToAnyPublisher()
     }
 
@@ -149,7 +157,7 @@ struct StorageManager {
                                          expiresBefore: expiresBefore,
                                          query: query,
                                          categoryIds: categoryIds)
-            .map { $0.map { IngredientInfo(id: $0.id, name: $0.name, quantity: String($0.totalQuantity)) } }
+            .map { $0.map { IngredientInfo(id: $0.id, name: $0.name, quantity: String($0.totalQuantityDescription)) } }
             .eraseToAnyPublisher()
     }
 

--- a/ChopChop/ViewModels/Recipes/RecipeFormViewModel.swift
+++ b/ChopChop/ViewModels/Recipes/RecipeFormViewModel.swift
@@ -20,7 +20,7 @@ class RecipeFormViewModel: ObservableObject {
 
     var pickerSourceType: UIImagePickerController.SourceType = .photoLibrary
 
-    @Published var hasError: Bool = false
+    @Published var hasError = false
     @Published var isShowingPhotoLibrary = false
     @Published var image = UIImage()
     @Published var recipeName = ""

--- a/ChopChop/Views/Ingredients/IngredientCollectionView.swift
+++ b/ChopChop/Views/Ingredients/IngredientCollectionView.swift
@@ -156,7 +156,7 @@ struct IngredientCollectionView: View {
                 Image(uiImage: viewModel.getIngredientImage(ingredient: ingredient))
                     .resizable()
                     .scaledToFill()
-                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                     .aspectRatio(1, contentMode: .fill)
                     .cornerRadius(10)
                     .clipped()

--- a/ChopChop/Views/Recipes/RecipeCollectionView.swift
+++ b/ChopChop/Views/Recipes/RecipeCollectionView.swift
@@ -143,7 +143,7 @@ struct RecipeCollectionView: View {
         Image("recipe")
             .resizable()
             .scaledToFill()
-            .frame(minWidth: 0, maxWidth: .infinity)
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
             .aspectRatio(1, contentMode: .fill)
             .cornerRadius(10)
             .clipped()


### PR DESCRIPTION
Add publishers for individual recipes/ingredients so we don't have to rely on `ObservableObjects`.